### PR TITLE
よくあるテーブルのパターンを追加

### DIFF
--- a/src/patterns/CommonTable/CommonTable.stories.tsx
+++ b/src/patterns/CommonTable/CommonTable.stories.tsx
@@ -1,0 +1,75 @@
+import { Story } from '@storybook/react'
+import { ComponentProps } from 'react'
+
+import { CommonTable } from './CommonTable'
+
+const Template: Story<ComponentProps<typeof CommonTable>> = (props) => (
+  <div style={{ padding: '32px' }}>
+    <CommonTable {...props} />
+  </div>
+)
+
+export const Default = Template.bind({})
+Default.storyName = '基本'
+Default.args = {
+  title: 'よくあるテーブルのタイトル',
+  description:
+    'よくあるテーブルの説明テキストです。よくあるテーブルの説明テキストです。よくあるテーブルの説明テキストです。よくあるテーブルの説明テキストです。よくあるテーブルの説明テキストです。',
+  pagination: {
+    currentPage: 1,
+    limitValue: 25,
+    totalCount: 100,
+    totalPages: 4,
+  },
+  searchValue: '',
+}
+
+export const InitialState = Template.bind({})
+InitialState.storyName = '初期状態'
+InitialState.args = {
+  ...Default.args,
+  pagination: {
+    currentPage: 0,
+    limitValue: 0,
+    totalCount: 0,
+    totalPages: 0,
+  },
+  searchValue: '',
+}
+
+export const NoSearchResult = Template.bind({})
+NoSearchResult.storyName = '検索結果なし'
+NoSearchResult.args = {
+  ...Default.args,
+  pagination: {
+    currentPage: 0,
+    limitValue: 0,
+    totalCount: 0,
+    totalPages: 0,
+  },
+  searchValue: 'あああ',
+}
+
+export const LessThanOnePage = Template.bind({})
+LessThanOnePage.storyName = '1ページ未満'
+LessThanOnePage.args = {
+  ...Default.args,
+  pagination: {
+    currentPage: 1,
+    limitValue: 3,
+    totalCount: 3,
+    totalPages: 1,
+  },
+  searchValue: 'あああ',
+}
+
+export const NoDescription = Template.bind({})
+NoDescription.storyName = 'テーブルの説明なし'
+NoDescription.args = {
+  ...Default.args,
+  description: '',
+}
+
+export default {
+  title: 'よくあるテーブル',
+}

--- a/src/patterns/CommonTable/CommonTable.stories.tsx
+++ b/src/patterns/CommonTable/CommonTable.stories.tsx
@@ -22,6 +22,13 @@ Default.args = {
     totalPages: 4,
   },
   searchValue: '',
+  sampleObjects: [...Array(25).fill(0)].map((_, i) => ({
+    id: `${i}`,
+    name: `オブジェクト${i + 1}`,
+    info1: `${i + 1}`,
+    info2: `2021-01-0${i + 1}`,
+    status: 'ステータス',
+  })),
 }
 
 export const InitialState = Template.bind({})
@@ -61,6 +68,13 @@ LessThanOnePage.args = {
     totalPages: 1,
   },
   searchValue: 'あああ',
+  sampleObjects: [...Array(3).fill(0)].map((_, i) => ({
+    id: `${i}`,
+    name: `オブジェクト${i + 1}`,
+    info1: `${i + 1}`,
+    info2: `2021-01-0${i + 1}`,
+    status: 'ステータス',
+  })),
 }
 
 export const NoDescription = Template.bind({})

--- a/src/patterns/CommonTable/CommonTable.tsx
+++ b/src/patterns/CommonTable/CommonTable.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Base, Cluster, Pagination, Stack } from 'smarthr-ui'
+import styled from 'styled-components'
+import { Table, TableOperationArea, TemporaryOperationArea, TitleArea } from './components'
+
+type Props = {
+  title: string
+  description: string
+  searchValue: string
+  pagination: { totalPages: number; currentPage: number; totalCount: number; limitValue: number }
+}
+
+export const CommonTable: React.FC<Props> = (props) => {
+  const { title, description, searchValue, pagination } = props
+  const { totalPages, currentPage, totalCount } = pagination
+
+  const TitleAreaWrapper: React.FC<React.PropsWithChildren> = ({ children }) =>
+    description ? <>{children}</> : <Cluster align="center">{children}</Cluster>
+
+  const isInitialState = searchValue === '' && totalCount === 0
+  const hasNoSearchResult = searchValue !== '' && totalCount === 0
+
+  return (
+    <Stack gap={1}>
+      <TitleAreaWrapper>
+        <TitleArea title={title} description={description} />
+        <StyledTableOperationArea isInitialState={isInitialState} />
+      </TitleAreaWrapper>
+      <Stack gap={1.5}>
+        <Base>
+          {!isInitialState && <TemporaryOperationArea pagination={pagination} searchValue={searchValue} />}
+          <Table isInitialState={isInitialState} hasNoSearchResult={hasNoSearchResult} />
+        </Base>
+        {totalPages > 1 && !isInitialState && !hasNoSearchResult && (
+          <Center>
+            <Pagination current={currentPage} total={totalPages} onClick={() => null} />
+          </Center>
+        )}
+      </Stack>
+    </Stack>
+  )
+}
+
+const Center = styled.div`
+  display: flex;
+  justify-content: center;
+`
+
+const StyledTableOperationArea = styled(TableOperationArea)`
+  margin-left: auto;
+`

--- a/src/patterns/CommonTable/CommonTable.tsx
+++ b/src/patterns/CommonTable/CommonTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ComponentProps } from 'react'
 import { Base, Cluster, Pagination, Stack } from 'smarthr-ui'
 import styled from 'styled-components'
 import { Table, TableOperationArea, TemporaryOperationArea, TitleArea } from './components'
@@ -8,10 +8,11 @@ type Props = {
   description: string
   searchValue: string
   pagination: { totalPages: number; currentPage: number; totalCount: number; limitValue: number }
+  sampleObjects: ComponentProps<typeof Table>['sampleObjects']
 }
 
 export const CommonTable: React.FC<Props> = (props) => {
-  const { title, description, searchValue, pagination } = props
+  const { title, description, searchValue, pagination, sampleObjects } = props
   const { totalPages, currentPage, totalCount } = pagination
 
   const TitleAreaWrapper: React.FC<React.PropsWithChildren> = ({ children }) =>
@@ -29,7 +30,7 @@ export const CommonTable: React.FC<Props> = (props) => {
       <Stack gap={1.5}>
         <Base>
           {!isInitialState && <TemporaryOperationArea pagination={pagination} searchValue={searchValue} />}
-          <Table isInitialState={isInitialState} hasNoSearchResult={hasNoSearchResult} />
+          <Table isInitialState={isInitialState} hasNoSearchResult={hasNoSearchResult} sampleObjects={sampleObjects} />
         </Base>
         {totalPages > 1 && !isInitialState && !hasNoSearchResult && (
           <Center>

--- a/src/patterns/CommonTable/components/PageCounter.tsx
+++ b/src/patterns/CommonTable/components/PageCounter.tsx
@@ -1,0 +1,44 @@
+import { Text } from 'smarthr-ui'
+import styled, { css } from 'styled-components'
+
+export interface Props {
+  start: number
+  end: number
+  total?: number
+}
+
+export const PageCounter: React.FC<Props> = ({ start, end, total }) => (
+  <Container>
+    <Text weight="bold" as="b">
+      {start}
+    </Text>
+    -
+    <Text weight="bold" as="b">
+      {end}
+    </Text>
+    {total === undefined ? (
+      '件'
+    ) : (
+      <>
+        /
+        <Text weight="bold" as="b">
+          {total}
+        </Text>
+        件中
+      </>
+    )}
+  </Container>
+)
+
+const Container = styled.div`
+  ${({ theme: { fontSize } }) => css`
+    display: inline-flex;
+    align-items: baseline;
+    font-size: ${fontSize.M};
+    column-gap: 0.5ch;
+
+    & > b {
+      letter-spacing: 0.025em;
+    }
+  `}
+`

--- a/src/patterns/CommonTable/components/PageCounter.tsx
+++ b/src/patterns/CommonTable/components/PageCounter.tsx
@@ -7,6 +7,7 @@ export interface Props {
   total?: number
 }
 
+// TODO: smarthr-ui で提供する
 export const PageCounter: React.FC<Props> = ({ start, end, total }) => (
   <Container>
     <Text weight="bold" as="b">

--- a/src/patterns/CommonTable/components/Table.stories.tsx
+++ b/src/patterns/CommonTable/components/Table.stories.tsx
@@ -1,0 +1,31 @@
+import { Story } from '@storybook/react'
+import { ComponentProps } from 'react'
+
+import { Table } from '.'
+
+const Template: Story<ComponentProps<typeof Table>> = (props) => <Table {...props} />
+
+export const Default = Template.bind({})
+Default.storyName = '基本'
+Default.args = {
+  isInitialState: false,
+  hasNoSearchResult: false,
+}
+
+export const InitialState = Template.bind({})
+InitialState.storyName = '初期状態'
+InitialState.args = {
+  ...Default.args,
+  isInitialState: true,
+}
+
+export const NoSearchResult = Template.bind({})
+NoSearchResult.storyName = '検索結果なし'
+NoSearchResult.args = {
+  ...Default.args,
+  hasNoSearchResult: true,
+}
+
+export default {
+  title: 'よくあるテーブル/テーブル',
+}

--- a/src/patterns/CommonTable/components/Table.stories.tsx
+++ b/src/patterns/CommonTable/components/Table.stories.tsx
@@ -10,6 +10,13 @@ Default.storyName = '基本'
 Default.args = {
   isInitialState: false,
   hasNoSearchResult: false,
+  sampleObjects: [...Array(3).fill(0)].map((_, i) => ({
+    id: `${i}`,
+    name: `オブジェクト${i + 1}`,
+    info1: `${i + 1}`,
+    info2: `2021-01-0${i + 1}`,
+    status: 'ステータス',
+  })),
 }
 
 export const InitialState = Template.bind({})

--- a/src/patterns/CommonTable/components/Table.tsx
+++ b/src/patterns/CommonTable/components/Table.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import {
+  Button,
+  CheckBox,
+  Cluster,
+  FaCopyIcon,
+  FaPenIcon,
+  FaPlusCircleIcon,
+  FaTrashIcon,
+  Table as ShrTable,
+  Stack,
+  StatusLabel,
+  Td,
+  Text,
+  Th,
+} from 'smarthr-ui'
+import styled, { css } from 'styled-components'
+
+type Props = {
+  isInitialState: boolean
+  hasNoSearchResult: boolean
+}
+
+export const Table: React.FC<Props> = (props) => {
+  const { isInitialState, hasNoSearchResult } = props
+
+  return (
+    <ShrTable>
+      <thead>
+        <CheckBoxTh>{!isInitialState && !hasNoSearchResult && <CheckBox />}</CheckBoxTh>
+        <Th>ステータス</Th>
+        <Th>オブジェクト名</Th>
+        <Th>オブジェクトの情報</Th>
+        <Th>オブジェクトの情報</Th>
+        <Th>操作</Th>
+      </thead>
+      <tbody>
+        {isInitialState ? (
+          <tr>
+            <EmptyCell colSpan={6}>
+              <Stack>
+                <Text>オブジェクトはまだ登録されていません。</Text>
+                <div>
+                  <Button variant="secondary" size="s" prefix={<FaPlusCircleIcon />}>
+                    項目を追加
+                  </Button>
+                </div>
+              </Stack>
+            </EmptyCell>
+          </tr>
+        ) : hasNoSearchResult ? (
+          <tr>
+            <EmptyCell colSpan={6}>
+              <Text as="p">
+                <Text>お探しの条件にに該当するオブジェクトはありません。</Text>
+                <br />
+                <Text>別の条件をお試しください。</Text>
+              </Text>
+            </EmptyCell>
+          </tr>
+        ) : (
+          [...new Array(3)].map((_, i) => {
+            return (
+              <tr key={i}>
+                <Td>
+                  <CheckBox />
+                </Td>
+                <Td>
+                  <StatusLabel>ステータス</StatusLabel>
+                </Td>
+                <Td>{`オブジェクト${i + 1}`}</Td>
+                <Td>{i + 1}</Td>
+                <Td>{`2021-01-0${i + 1}`}</Td>
+                <Td>
+                  <Cluster>
+                    <Button variant="secondary" size="s" prefix={<FaPenIcon />}>
+                      操作1
+                    </Button>
+                    <Button variant="secondary" size="s" prefix={<FaCopyIcon />}>
+                      操作2
+                    </Button>
+                    <Button variant="secondary" size="s" prefix={<FaTrashIcon />}>
+                      操作3
+                    </Button>
+                  </Cluster>
+                </Td>
+              </tr>
+            )
+          })
+        )}
+      </tbody>
+    </ShrTable>
+  )
+}
+
+const CheckBoxTh = styled(Th)`
+  width: 16px;
+`
+
+const EmptyCell = styled(Td)`
+  text-align: center;
+  ${({ theme: { space } }) => css`
+    padding: ${space(4)};
+  `}
+`

--- a/src/patterns/CommonTable/components/Table.tsx
+++ b/src/patterns/CommonTable/components/Table.tsx
@@ -19,10 +19,17 @@ import styled, { css } from 'styled-components'
 type Props = {
   isInitialState: boolean
   hasNoSearchResult: boolean
+  sampleObjects: Array<{
+    id: string
+    status: string
+    name: string
+    info1: string
+    info2: string
+  }>
 }
 
 export const Table: React.FC<Props> = (props) => {
-  const { isInitialState, hasNoSearchResult } = props
+  const { isInitialState, hasNoSearchResult, sampleObjects } = props
 
   return (
     <ShrTable>
@@ -59,34 +66,32 @@ export const Table: React.FC<Props> = (props) => {
             </EmptyCell>
           </tr>
         ) : (
-          [...new Array(3)].map((_, i) => {
-            return (
-              <tr key={i}>
-                <Td>
-                  <CheckBox />
-                </Td>
-                <Td>
-                  <StatusLabel>ステータス</StatusLabel>
-                </Td>
-                <Td>{`オブジェクト${i + 1}`}</Td>
-                <Td>{i + 1}</Td>
-                <Td>{`2021-01-0${i + 1}`}</Td>
-                <Td>
-                  <Cluster>
-                    <Button variant="secondary" size="s" prefix={<FaPenIcon />}>
-                      操作1
-                    </Button>
-                    <Button variant="secondary" size="s" prefix={<FaCopyIcon />}>
-                      操作2
-                    </Button>
-                    <Button variant="secondary" size="s" prefix={<FaTrashIcon />}>
-                      操作3
-                    </Button>
-                  </Cluster>
-                </Td>
-              </tr>
-            )
-          })
+          sampleObjects.map(({ id, status, name, info1, info2 }) => (
+            <tr key={id}>
+              <Td>
+                <CheckBox />
+              </Td>
+              <Td>
+                <StatusLabel>{status}</StatusLabel>
+              </Td>
+              <Td>{name}</Td>
+              <Td>{info1}</Td>
+              <Td>{info2}</Td>
+              <Td>
+                <Cluster>
+                  <Button variant="secondary" size="s" prefix={<FaPenIcon />}>
+                    操作1
+                  </Button>
+                  <Button variant="secondary" size="s" prefix={<FaCopyIcon />}>
+                    操作2
+                  </Button>
+                  <Button variant="secondary" size="s" prefix={<FaTrashIcon />}>
+                    操作3
+                  </Button>
+                </Cluster>
+              </Td>
+            </tr>
+          ))
         )}
       </tbody>
     </ShrTable>
@@ -94,6 +99,7 @@ export const Table: React.FC<Props> = (props) => {
 }
 
 const CheckBoxTh = styled(Th)`
+  // TODO: smarthr-ui 側でチェックボックス用の Th を指定できるようにする
   width: 16px;
 `
 

--- a/src/patterns/CommonTable/components/Table.tsx
+++ b/src/patterns/CommonTable/components/Table.tsx
@@ -48,7 +48,7 @@ export const Table: React.FC<Props> = (props) => {
               <Stack>
                 <Text>オブジェクトはまだ登録されていません。</Text>
                 <div>
-                  <Button variant="secondary" size="s" prefix={<FaPlusCircleIcon />}>
+                  <Button size="s" prefix={<FaPlusCircleIcon />}>
                     項目を追加
                   </Button>
                 </div>
@@ -79,13 +79,13 @@ export const Table: React.FC<Props> = (props) => {
               <Td>{info2}</Td>
               <Td>
                 <Cluster>
-                  <Button variant="secondary" size="s" prefix={<FaPenIcon />}>
+                  <Button size="s" prefix={<FaPenIcon />}>
                     操作1
                   </Button>
-                  <Button variant="secondary" size="s" prefix={<FaCopyIcon />}>
+                  <Button size="s" prefix={<FaCopyIcon />}>
                     操作2
                   </Button>
-                  <Button variant="secondary" size="s" prefix={<FaTrashIcon />}>
+                  <Button size="s" prefix={<FaTrashIcon />}>
                     操作3
                   </Button>
                 </Cluster>

--- a/src/patterns/CommonTable/components/TableOperationArea.stories.tsx
+++ b/src/patterns/CommonTable/components/TableOperationArea.stories.tsx
@@ -1,0 +1,22 @@
+import { Story } from '@storybook/react'
+import { ComponentProps } from 'react'
+
+import { TableOperationArea } from '.'
+
+const Template: Story<ComponentProps<typeof TableOperationArea>> = (props) => <TableOperationArea {...props} />
+
+export const Default = Template.bind({})
+Default.storyName = '基本'
+Default.args = {
+  isInitialState: false,
+}
+
+export const IsInitialState = Template.bind({})
+IsInitialState.storyName = '初期状態'
+IsInitialState.args = {
+  isInitialState: true,
+}
+
+export default {
+  title: 'よくあるテーブル/テーブル操作エリア',
+}

--- a/src/patterns/CommonTable/components/TableOperationArea.tsx
+++ b/src/patterns/CommonTable/components/TableOperationArea.tsx
@@ -1,0 +1,29 @@
+import { Button, Cluster, DropdownButton, FaArrowsAltVIcon, FaPlusCircleIcon } from 'smarthr-ui'
+
+type Props = {
+  className?: string
+  isInitialState: boolean
+}
+
+export const TableOperationArea: React.FC<Props> = (props) => {
+  const { className, isInitialState } = props
+
+  return (
+    <Cluster className={className} gap={0.5}>
+      {!isInitialState && (
+        <>
+          <Button variant="secondary" prefix={<FaArrowsAltVIcon />}>
+            並べ替え
+          </Button>
+        </>
+      )}
+      <DropdownButton label="一括操作">
+        <Button variant="secondary">オブジェクトの一括追加（CSV）</Button>
+        {!isInitialState && <Button variant="secondary">オブジェクトの一括更新（CSV）</Button>}
+      </DropdownButton>
+      <Button variant="secondary" prefix={<FaPlusCircleIcon />}>
+        オブジェクトを追加
+      </Button>
+    </Cluster>
+  )
+}

--- a/src/patterns/CommonTable/components/TableOperationArea.tsx
+++ b/src/patterns/CommonTable/components/TableOperationArea.tsx
@@ -12,18 +12,14 @@ export const TableOperationArea: React.FC<Props> = (props) => {
     <Cluster className={className} gap={0.5}>
       {!isInitialState && (
         <>
-          <Button variant="secondary" prefix={<FaArrowsAltVIcon />}>
-            並べ替え
-          </Button>
+          <Button prefix={<FaArrowsAltVIcon />}>並べ替え</Button>
         </>
       )}
       <DropdownButton label="一括操作">
-        <Button variant="secondary">オブジェクトの一括追加（CSV）</Button>
-        {!isInitialState && <Button variant="secondary">オブジェクトの一括更新（CSV）</Button>}
+        <Button>オブジェクトの一括追加（CSV）</Button>
+        {!isInitialState && <Button>オブジェクトの一括更新（CSV）</Button>}
       </DropdownButton>
-      <Button variant="secondary" prefix={<FaPlusCircleIcon />}>
-        オブジェクトを追加
-      </Button>
+      <Button prefix={<FaPlusCircleIcon />}>オブジェクトを追加</Button>
     </Cluster>
   )
 }

--- a/src/patterns/CommonTable/components/TemporaryOperationArea.stories.tsx
+++ b/src/patterns/CommonTable/components/TemporaryOperationArea.stories.tsx
@@ -1,0 +1,35 @@
+import { Story } from '@storybook/react'
+import { ComponentProps } from 'react'
+
+import { TemporaryOperationArea } from '.'
+
+const Template: Story<ComponentProps<typeof TemporaryOperationArea>> = (props) => <TemporaryOperationArea {...props} />
+
+export const Default = Template.bind({})
+Default.storyName = '基本'
+Default.args = {
+  pagination: {
+    currentPage: 1,
+    limitValue: 25,
+    totalCount: 100,
+    totalPages: 4,
+  },
+  searchValue: '',
+}
+
+export const NoSearchResult = Template.bind({})
+NoSearchResult.storyName = '検索結果なし'
+NoSearchResult.args = {
+  ...Default.args,
+  pagination: {
+    currentPage: 0,
+    limitValue: 0,
+    totalCount: 0,
+    totalPages: 0,
+  },
+  searchValue: 'あああ',
+}
+
+export default {
+  title: 'よくあるテーブル/一時操作エリア',
+}

--- a/src/patterns/CommonTable/components/TemporaryOperationArea.tsx
+++ b/src/patterns/CommonTable/components/TemporaryOperationArea.tsx
@@ -1,0 +1,52 @@
+import { Button, Cluster, FaCloudDownloadAltIcon, FaSearchIcon, FilterDropdown, Input, Pagination } from 'smarthr-ui'
+import styled, { css } from 'styled-components'
+import { PageCounter } from './PageCounter'
+
+type Props = {
+  searchValue: string
+  pagination: { totalPages: number; currentPage: number; totalCount: number; limitValue: number }
+}
+
+export const TemporaryOperationArea: React.FC<Props> = (props) => {
+  const {
+    searchValue,
+    pagination: { totalPages, currentPage, totalCount, limitValue },
+  } = props
+
+  return (
+    <HeaderCluster justify="space-between" align="center">
+      <form role="search" onSubmit={(e) => e.preventDefault()}>
+        <Cluster align="center" gap={1}>
+          <Cluster gap={0.5}>
+            <label>
+              <Input
+                prefix={<FaSearchIcon size={14} alt="検索" color="TEXT_GREY" />}
+                placeholder="オブジェクト名"
+                value={searchValue}
+              />
+            </label>
+            <Button variant="secondary" type="submit">
+              検索
+            </Button>
+          </Cluster>
+          <FilterDropdown onApply={() => null}>絞り込みの中身</FilterDropdown>
+          <Button variant="secondary" type="submit" prefix={<FaCloudDownloadAltIcon />}>
+            ダウンロード
+          </Button>
+        </Cluster>
+      </form>
+      {totalCount > 0 && (
+        <Cluster gap={1} align="center">
+          <PageCounter start={1 + (currentPage - 1) * limitValue} end={currentPage * limitValue} total={totalCount} />
+          <Pagination current={currentPage} total={totalPages} withoutNumbers onClick={() => null} />
+        </Cluster>
+      )}
+    </HeaderCluster>
+  )
+}
+
+const HeaderCluster = styled(Cluster)`
+  ${({ theme: { space } }) => css`
+    padding: ${space(1)};
+  `}
+`

--- a/src/patterns/CommonTable/components/TemporaryOperationArea.tsx
+++ b/src/patterns/CommonTable/components/TemporaryOperationArea.tsx
@@ -14,16 +14,12 @@ export const TemporaryOperationArea: React.FC<Props> = (props) => {
   } = props
 
   return (
-    <HeaderCluster justify="space-between" align="center">
+    <Wrapper justify="space-between" align="center">
       <form role="search" onSubmit={(e) => e.preventDefault()}>
         <Cluster align="center" gap={1}>
           <Cluster gap={0.5}>
             <label>
-              <Input
-                prefix={<FaSearchIcon size={14} alt="検索" color="TEXT_GREY" />}
-                placeholder="オブジェクト名"
-                value={searchValue}
-              />
+              <Input prefix={<FaSearchIcon alt="検索" color="TEXT_GREY" />} placeholder="オブジェクト名" value={searchValue} />
             </label>
             <Button variant="secondary" type="submit">
               検索
@@ -41,11 +37,11 @@ export const TemporaryOperationArea: React.FC<Props> = (props) => {
           <Pagination current={currentPage} total={totalPages} withoutNumbers onClick={() => null} />
         </Cluster>
       )}
-    </HeaderCluster>
+    </Wrapper>
   )
 }
 
-const HeaderCluster = styled(Cluster)`
+const Wrapper = styled(Cluster)`
   ${({ theme: { space } }) => css`
     padding: ${space(1)};
   `}

--- a/src/patterns/CommonTable/components/TemporaryOperationArea.tsx
+++ b/src/patterns/CommonTable/components/TemporaryOperationArea.tsx
@@ -21,12 +21,10 @@ export const TemporaryOperationArea: React.FC<Props> = (props) => {
             <label>
               <Input prefix={<FaSearchIcon alt="検索" color="TEXT_GREY" />} placeholder="オブジェクト名" value={searchValue} />
             </label>
-            <Button variant="secondary" type="submit">
-              検索
-            </Button>
+            <Button type="submit">検索</Button>
           </Cluster>
           <FilterDropdown onApply={() => null}>絞り込みの中身</FilterDropdown>
-          <Button variant="secondary" type="submit" prefix={<FaCloudDownloadAltIcon />}>
+          <Button type="submit" prefix={<FaCloudDownloadAltIcon />}>
             ダウンロード
           </Button>
         </Cluster>

--- a/src/patterns/CommonTable/components/TitleArea.stories.tsx
+++ b/src/patterns/CommonTable/components/TitleArea.stories.tsx
@@ -1,0 +1,18 @@
+import { Story } from '@storybook/react'
+import { ComponentProps } from 'react'
+
+import { TitleArea } from '.'
+
+const Template: Story<ComponentProps<typeof TitleArea>> = (props) => <TitleArea {...props} />
+
+export const Default = Template.bind({})
+Default.storyName = '基本'
+Default.args = {
+  title: 'よくあるテーブルのタイトル',
+  description:
+    'よくあるテーブルの説明テキストです。よくあるテーブルの説明テキストです。よくあるテーブルの説明テキストです。よくあるテーブルの説明テキストです。よくあるテーブルの説明テキストです。',
+}
+
+export default {
+  title: 'よくあるテーブル/タイトルエリア',
+}

--- a/src/patterns/CommonTable/components/TitleArea.tsx
+++ b/src/patterns/CommonTable/components/TitleArea.tsx
@@ -1,0 +1,19 @@
+import { Cluster, Heading, Stack, Text } from 'smarthr-ui'
+
+type Props = {
+  title: string
+  description: string
+}
+
+export const TitleArea: React.FC<Props> = (props) => {
+  const { title, description } = props
+
+  return (
+    <Stack gap={1}>
+      <Heading tag="h1" type="screenTitle">
+        {title}
+      </Heading>
+      {description && <Text as="p">{description}</Text>}
+    </Stack>
+  )
+}

--- a/src/patterns/CommonTable/components/index.ts
+++ b/src/patterns/CommonTable/components/index.ts
@@ -1,0 +1,5 @@
+export { Table } from './Table'
+export { TitleArea } from './TitleArea'
+export { TableOperationArea } from './TableOperationArea'
+export { TemporaryOperationArea } from './TemporaryOperationArea'
+export { PageCounter } from './PageCounter'

--- a/src/patterns/CommonTable/index.ts
+++ b/src/patterns/CommonTable/index.ts
@@ -1,0 +1,1 @@
+export { CommonTable } from './CommonTable'


### PR DESCRIPTION
## やったこと

よくあるテーブルのパターンを追加
https://smarthr.design/products/design-patterns/smarthr-table/#h3-6

割とボリュームが大きかったので、いくつかのStoryに分けてます

- よくあるテーブル本体（全てのエリアを組み合わせたもの）
- テーブル
- タイトルエリア
- テーブル操作エリア
- 一時操作エリア

## 悩ましポイント

デザインシステム的には、`一時操作エリア` にはテーブルヘッダと、下部の `Pagenation` に分かれているが、コンポーネントを切り出すのが大変だったので、`一時操作エリア` コンポーネントにはテーブルヘッダだけを含める形にした
https://smarthr.design/static/6f451517a9fd44f68b74ee22404248e8/38ca0/smarthr-table-temporary-actionarea.png

↑書いてて思ったけど、`一時操作エリア` コンポーネントに `children` として `Table` を受け取るようにすればできるかも。ただ、そこまでやるかは微妙カモ