### PR TITLE
💩: デザインシステム側で react-live をかました時にバグるので暫定修正

### DIFF
--- a/src/patterns/SelectCompanyAccount/SelectCompanyAccount.tsx
+++ b/src/patterns/SelectCompanyAccount/SelectCompanyAccount.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components'
 
 import { Base, Button, Heading, RadioButton, Stack } from 'smarthr-ui'
 
-const companyList = [...Array(4)].map((_, id) => {
+const companyList = [...Array(4).fill(0)].map((_, id) => {
   return { id, name: `株式会社スマートエイチアール${id}` }
 })
 

--- a/src/patterns/Spacing/Dialog.tsx
+++ b/src/patterns/Spacing/Dialog.tsx
@@ -25,7 +25,7 @@ export const SpacingDialog: React.FC<Props> = ({ withInformationPanel, numberOfB
         選択した評価を削除します。評価シートの入力内容や評価者設定などのデータも削除されます。削除された評価は元に戻せません。
       </Text>
       <Stack gap={1.5}>
-        {[...Array(numberOfBlocks)].map((_, i) => (
+        {[...Array(numberOfBlocks).fill(0)].map((_, i) => (
           <Fieldset key={i}>
             <legend>
               <Heading type="blockTitle" tag="h3">


### PR DESCRIPTION
react-live を使うと、`[...Array(4)].map(() => ())` と書いた時に配列が空になってしまう。