### PR TITLE
renovateのautomergeの対象を広げる

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>kufu/renovate-config"
-  ]
+  "extends": ["local>kufu/renovate-config"],
+  "npm": {
+    "postUpdateOptions": ["yarnDedupeHighest"],
+    "packageRules": [
+      {
+        "matchDepTypes": ["dependencies"],
+        "matchUpdateTypes": ["minor", "patch"],
+        "excludeDepNames": ["smarthr-ui", "smarthr-normalize-css"],
+        "automerge": true
+      },
+      {
+        "matchDepTypes": ["devDependencies"],
+        "matchUpdateTypes": ["minor", "patch"],
+        "automerge": true
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Chromaticさえ通っていれば良いと思うので、devDependenciesとdependenciesともに、minorとpatchでautomergeを有効にしました。

smarthr-uiとsmarthr-normalize-cssだけ手動で見たいかなと思ったので、automergeの対象からは除外してます。